### PR TITLE
Fix remove-if symbol function definition void err

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -31,6 +31,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ivy)
 (require 'subr-x)
 
@@ -116,7 +117,7 @@ For example, a path /a/b/c/d/e/f.el will be shortened to /a/…/e/f.el."
   "Join all the non-nil column of COLUMNS."
   (mapconcat
    #'identity
-   (remove-if #'null columns)
+   (cl-remove-if #'null columns)
    ivy-rich-switch-buffer-delimiter))
 
 (defun ivy-rich-switch-buffer-indicators ()


### PR DESCRIPTION
ivy-rich makes use of remove-if. On my Emacs 25.1.1 this would result
in the following error at first invocation:

mapconcat: Symbol’s function definition is void: remove-if

By adding a (require 'cl-lib) and using cl-remove-if instead of
remove-if (as is done by ivy.el itself), this error is resolved.