### PR TITLE
Fix for using ivy-rich with dired when accessing a path via a symlink that is shorter than the canonical path

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -229,13 +229,12 @@ or /a/…/f.el."
          ;; Find the file name or `nil'
          (filename
           (if (buffer-file-name)
-              (if (and (buffer-file-name)
-                       (string-match "^https?:\\/\\/" (buffer-file-name))
+              (if (and (string-match "^https?:\\/\\/" (buffer-file-name))
                        (not (file-exists-p (buffer-file-name))))
                   nil
                 (file-truename (buffer-file-name)))
             (if (eq major-mode 'dired-mode)
-                (dired-current-directory)
+                (file-truename (dired-current-directory))
               nil)))
          (path (cond ((or (memq ivy-rich-path-style '(full absolute))
                           (and (null ivy-rich-parse-remote-file-path)

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -218,6 +218,7 @@ or /a/…/f.el."
                              ivy-rich-switch-buffer-mode-max-length
                              (if project ivy-rich-switch-buffer-project-max-length 0)
                              (* 4 (length ivy-rich-switch-buffer-delimiter))
+                             (if (eq 'ivy-format-function-arrow ivy-format-function) 2 0)
                              2))        ; Fixed the unexpected wrapping in terminal
          ;; Find the project root directory or `default-directory'
          (root (file-truename


### PR DESCRIPTION
To reproduce:

$ cd $(mktemp -d)
$ mkdir -p a/b
$ ln -s a/b c
$ cd c
$ emacs -nw .
M-x ivy-switch-buffer

It will fail with something like:

Args out of range: "/tmp/tmp.OlOvGglcOi/c/", 24, nil

While I was in there, I also removed an unnecessary check for (buffer-name) that was just asserted in the if statement above.