### PR TITLE
Make ivy-rich-switch-buffer-path more robust.

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -245,8 +245,8 @@ or /a/…/f.el."
                       (abbreviate-file-name (or filename root)))
                      ((or (eq ivy-rich-path-style 'relative)
                           t)            ; make 'relative default
-                      (if filename
-                          (substring-no-properties filename (length root))
+                      (if (and filename root)
+                          (substring-no-properties (string-remove-prefix root filename))
                         "")))))
     (ivy-rich-switch-buffer-pad
      (ivy-rich-switch-buffer-shorten-path path path-max-length)


### PR DESCRIPTION
Double check that `filename' and `root' are non nil and then use
`string-remove-prefix' to remove `root' from `filename'.

An example of when the old code could blow up would be if you have a
buffer that is visiting file "/tmp/foo", but for whatever reason, the
user (or some other piece of elisp code) has decided to `setq'
`default-directory' to something else which happens to be longer than
the path to the file.

In that case trying to use ivy-rich-switch-buffer-transformer blows up
with "Args out of range".

This patch makes the function more robust to these sorts of weirdness.