### PR TITLE
Refactor to accommodate lexical bindings

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -1,4 +1,4 @@
-;;; ivy-rich.el --- More friendly display transformer for ivy.
+;;; ivy-rich.el --- More friendly display transformer for ivy. -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016 Yevgnen Koh
 
@@ -153,7 +153,7 @@ or /a/…/f.el."
    (cl-remove-if #'null columns)
    ivy-rich-switch-buffer-delimiter))
 
-(defun ivy-rich-switch-buffer-indicators ()
+(defun ivy-rich-switch-buffer-indicators (str)
   (let ((modified (if (and (buffer-modified-p)
                            (ivy-rich-switch-buffer-excluded-modes-p '(dired-mode shell-mode))
                            (ivy-rich-switch-buffer-user-buffer-p str))
@@ -183,7 +183,7 @@ or /a/…/f.el."
       (t (format "%d " size)))
      ivy-rich-switch-buffer-buffer-size-length t)))
 
-(defun ivy-rich-switch-buffer-buffer-name ()
+(defun ivy-rich-switch-buffer-buffer-name (str)
   (propertize
    (ivy-rich-switch-buffer-pad str ivy-rich-switch-buffer-name-max-length)
    'face
@@ -252,7 +252,7 @@ or /a/…/f.el."
      (ivy-rich-switch-buffer-shorten-path path path-max-length)
      path-max-length)))
 
-(defun ivy-rich-switch-buffer-virtual-buffer ()
+(defun ivy-rich-switch-buffer-virtual-buffer (str)
   (let* ((filename (file-name-nondirectory (expand-file-name str)))
          (filename (ivy-rich-switch-buffer-pad
                     filename
@@ -280,16 +280,16 @@ Currently the transformed format is
 | Buffer name | Buffer indicators | Major mode | Project | Path (Based on project root) |."
   (let ((buf (get-buffer str)))
     (cond (buf (with-current-buffer buf
-                 (let* ((indicator  (ivy-rich-switch-buffer-indicators))
+                 (let* ((indicator  (ivy-rich-switch-buffer-indicators str))
                         (size       (ivy-rich-switch-buffer-size))
-                        (buf-name   (ivy-rich-switch-buffer-buffer-name))
+                        (buf-name   (ivy-rich-switch-buffer-buffer-name str))
                         (mode       (ivy-rich-switch-buffer-major-mode))
                         (project    (ivy-rich-switch-buffer-project))
                         (path       (ivy-rich-switch-buffer-path project)))
                    (ivy-rich-switch-buffer-format `(,buf-name ,size ,indicator ,mode ,project ,path)))))
           ((and (eq ivy-virtual-abbreviate 'full)
                 ivy-rich-switch-buffer-align-virtual-buffer)
-           (ivy-rich-switch-buffer-virtual-buffer))
+           (ivy-rich-switch-buffer-virtual-buffer str))
           (t str))))
 
 (provide 'ivy-rich)


### PR DESCRIPTION
A minor refactor that passes `str` to the functions that need it instead of referencing a free variable.

My motivations:

+ Consistency -- `str` is the only (internally) free variable in ivy-rich
+ To make it a little easier to advise or use ivy-rich's functions, especially in an environment where lexical-binding is enabled.
  