### PR TITLE
Fixed Out of bounds error when the window is small

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -131,8 +131,9 @@ When LEFT is not nil, pad from left side."
   (let ((str-len (string-width str)))
     (cond ((< str-len len)
            (if left
-               (concat (make-string (- len (string-width str)) ? ) str)
-             (concat str (make-string (- len (string-width str)) ? ))))
+               (concat (make-string (- len str-len) ? ) str)
+             (concat str (make-string (- len str-len) ? ))))
+          ((<= len (- str-len)) "")
           ((> str-len len)
            (format "%s…" (substring str 0 (1- len))))
           (t str))))


### PR DESCRIPTION
ivy-rich-switch-buffer-pad would try to truncate strings past their
size; added simple check to detect such truncations and to return an empty string in that case.

fixes Yevgnen/ivy-rich#30