### PR TITLE
Add default icon for ivy-rich-switch-buffer-icon

### DIFF
--- a/README.org
+++ b/README.org
@@ -119,10 +119,13 @@ The package [[https://github.com/domtronn/all-the-icons.el][all-the-icons.el]] p
 emacs. For example, you can define a transformer
 
 #+BEGIN_SRC elisp
-  (defun ivy-rich-switch-buffer-icon (candidate)
-    (with-current-buffer
-        (get-buffer candidate)
-      (all-the-icons-icon-for-mode major-mode)))
+    (defun ivy-rich-switch-buffer-icon (candidate)
+      (with-current-buffer
+    	  (get-buffer candidate)
+	(let ((icon (all-the-icons-icon-for-mode major-mode)))
+	  (if (symbolp icon)
+	      (all-the-icons-icon-for-mode 'fundamental-mode)
+	    icon))))
 #+END_SRC
 
 and add it to the ~ivy-rich--display-transformers-List~


### PR DESCRIPTION
The current function shown in the readme for getting an icon fails when the mode is not defined in all-the-icons-mode-icon-list. This new function (repurposed from @a13 #24) solves the issue and should help new users wanting to use all-the-icons with ivy-rich.