### PR TITLE
Add counsel-find-file support to ivy-rich

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -460,6 +460,40 @@ or /a/…/f.el."
   (let ((package-vers (cadr (assoc-string candidate package-archive-contents))))
     (if package-vers (package-version-join (package-desc-version package-vers)) "")))
 
+;; Supports for `counsel-find-file'
+(defun ivy-rich-file-size (candidate)
+  (let ((candidate (expand-file-name candidate ivy--directory)))
+    (if (or (not (file-exists-p candidate)) (file-remote-p candidate))
+        ""
+      (let ((size (file-attribute-size (file-attributes candidate))))
+        (cond
+         ((> size 1000000) (format "%.1fM " (/ size 1000000.0)))
+         ((> size 1000) (format "%.1fk " (/ size 1000.0)))
+         (t (format "%d " size)))))))
+
+(defun ivy-rich-file-modes (candidate)
+  (let ((candidate (expand-file-name candidate ivy--directory)))
+    (if (or (not (file-exists-p candidate)) (file-remote-p candidate))
+        ""
+      (format "%s" (file-attribute-modes (file-attributes candidate))))))
+
+(defun ivy-rich-file-user (candidate)
+  (let ((candidate (expand-file-name candidate ivy--directory)))
+    (if (or (not (file-exists-p candidate)) (file-remote-p candidate))
+        ""
+      (let* ((user-id (file-attribute-user-id (file-attributes candidate)))
+             (user-name (user-login-name user-id)))
+        (format "%s" user-name)))))
+
+(defun ivy-rich-file-group (candidate)
+  (let ((candidate (expand-file-name candidate ivy--directory)))
+    (if (or (not (file-exists-p candidate)) (file-remote-p candidate))
+        ""
+      (let* ((group-id (file-attribute-group-id (file-attributes candidate)))
+             (group-function (if (fboundp #'group-name) #'group-name #'identity))
+             (group-name (funcall group-function group-id)))
+        (format "%s" group-name)))))
+
 ;; Definition of `ivy-rich-mode' ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defvar ivy-rich--original-display-transformers-list nil)  ; Backup list
 


### PR DESCRIPTION
Hi @Yevgnen I was wondering whether you would consider accepting a pull request to add support for `counsel-find-file` to `ivy-rich`. This was inspired by a discussion I saw on https://www.reddit.com/r/emacs/comments/9p5bwg/spends_2_hours_configuring_ranger_file_manager/ where users mentioned that in `helm` when searching for a file they would want to see some basic file information. I thought that would be neat to have in `ivy` as well.

I haven't seen any performance degradation since trying this out.

There could also be some code cleanup to have the file size code be shared between `ivy-rich-switch-buffer-size` and `ivy-rich-file-size`, if this is a feature that you are interested in I can have that code be shared.

![screenshot from 2018-10-18 13-58-54](https://user-images.githubusercontent.com/5892061/47183871-fc760b00-d2dd-11e8-86d8-71b8f47ce549.png)
