### PR TITLE
Allow ivy-rich-switch-buffer to use project.el

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -347,10 +347,10 @@ or /a/…/f.el."
                  (not (eq mode 'dired-mode))
                  (ivy-rich-switch-buffer-in-project-p candidate))
         ;; Find the project root directory or `default-directory'
-        (setq directory (cond ((ivy-rich--local-values buffer 'projectile-project-root))
-                              ((bound-and-true-p projectile-mode)
-                               (with-current-buffer buffer
-                                 (projectile-project-root)))
+        (setq directory (cond ((bound-and-true-p projectile-mode)
+                               (or (ivy-rich--local-values buffer 'projectile-project-root)
+                                   (with-current-buffer buffer
+                                     (projectile-project-root))))
                               ((require 'project nil t)
                                (with-current-buffer buffer
                                  (setq truenamep nil)

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -312,7 +312,7 @@ or /a/…/f.el."
      ""
      (symbol-name (ivy-rich--local-values candidate 'major-mode))))))
 
-(defun ivy-rich-switch-buffer-in-propject-p (candidate)
+(defun ivy-rich-switch-buffer-in-project-p (candidate)
   (with-current-buffer
       (get-buffer candidate)
     (unless (or (and (file-remote-p (or (buffer-file-name) default-directory))
@@ -320,32 +320,44 @@ or /a/…/f.el."
                 ;; Workaround for `browse-url-emacs' buffers , it changes
                 ;; `default-directory' to "http://" (#25)
                 (string-match "https?:\\/\\/" default-directory))
-      (if (bound-and-true-p projectile-mode)
-          (let ((project (projectile-project-name)))
-            (unless (string= project "-")
-              project))))))
+      (cond ((bound-and-true-p projectile-mode)
+             (let ((project (projectile-project-name)))
+               (unless (string= project "-")
+                 project)))
+            ((featurep 'project)
+             (let ((project (project-current)))
+               (when project
+                 (file-name-nondirectory
+                  (directory-file-name
+                   (car (project-roots project)))))))))))
 
 (defun ivy-rich-switch-buffer-project (candidate)
-  (or (ivy-rich-switch-buffer-in-propject-p candidate) ""))
+  (or (ivy-rich-switch-buffer-in-project-p candidate) ""))
 
 (defun ivy-rich--switch-buffer-root-and-filename (candidate)
-  (let* ((buffer (get-buffer candidate)))
+  (let* ((buffer (get-buffer candidate))
+         (truenamep t))
     (destructuring-bind
         (filename directory mode)
         (ivy-rich--local-values buffer '(buffer-file-name default-directory major-mode))
       ;; Only make sense when `filename' and `root' are both not `nil'
-      (unless (or (null filename)
-                  (null directory)
-                  (and (file-remote-p (or filename directory))
-                       (not ivy-rich-parse-remote-buffer))
-                  (eq mode 'dired-mode))
+      (when (and filename
+                 directory
+                 (if (file-remote-p filename) ivy-rich-parse-remote-buffer t)
+                 (not (eq mode 'dired-mode))
+                 (ivy-rich-switch-buffer-in-project-p candidate))
         ;; Find the project root directory or `default-directory'
-        (when (ivy-rich-switch-buffer-in-propject-p candidate)
-          (setq directory (or (ivy-rich--local-values buffer 'projectile-project-root)
-                              (with-current-buffer buffer (projectile-project-root))))
-          (if filename
-              (setq filename (or (ivy-rich--local-values buffer 'buffer-file-truename)
-                                 (file-truename filename)))))
+        (setq directory (cond ((ivy-rich--local-values buffer 'projectile-project-root))
+                              ((bound-and-true-p projectile-mode)
+                               (with-current-buffer buffer
+                                 (projectile-project-root)))
+                              ((featurep 'project)
+                               (with-current-buffer buffer
+                                 (setq truenamep nil)
+                                 (car (project-roots (project-current)))))))
+        (if truenamep
+            (setq filename (or (ivy-rich--local-values buffer 'buffer-file-truename)
+                               (file-truename filename))))
         (cons (expand-file-name directory)
               (expand-file-name filename))))))
 

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -324,7 +324,7 @@ or /a/…/f.el."
              (let ((project (projectile-project-name)))
                (unless (string= project "-")
                  project)))
-            ((featurep 'project)
+            ((require 'project nil t)
              (let ((project (project-current)))
                (when project
                  (file-name-nondirectory
@@ -351,7 +351,7 @@ or /a/…/f.el."
                               ((bound-and-true-p projectile-mode)
                                (with-current-buffer buffer
                                  (projectile-project-root)))
-                              ((featurep 'project)
+                              ((require 'project nil t)
                                (with-current-buffer buffer
                                  (setq truenamep nil)
                                  (car (project-roots (project-current)))))))


### PR DESCRIPTION
Emacs 26 comes with project.el which is a builtin replacement for some of the basic projectile functionality. If `projectile-mode` is not being used, check if project.el is available and use it instead.