### PR TITLE
Fix ivy--queue-exhibit: void-function nil error

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -391,14 +391,14 @@ or /a/…/f.el."
   (let ((doc (replace-regexp-in-string
               ":\\(\\(before\\|after\\)\\(-\\(whilte\\|until\\)\\)?\\|around\\|override\\|\\(filter-\\(args\\|return\\)\\)\\) advice:[ ]*‘.+?’[\r\n]+"
               ""
-              (or (documentation (intern candidate)) ""))))
+              (or (ignore-errors (documentation (intern-soft candidate))) ""))))
     (if (string-match "^\\(.+\\)\\([\r\n]\\)?" doc)
         (setq doc (match-string 1 doc))
       "")))
 
 (defun ivy-rich-counsel-variable-docstring (candidate)
   (let ((doc (documentation-property
-              (intern candidate) 'variable-documentation)))
+              (intern-soft candidate) 'variable-documentation)))
     (if (and doc (string-match "^\\(.+\\)\\([\r\n]\\)?" doc))
         (setq doc (match-string 1 doc))
       "")))


### PR DESCRIPTION
`(documentation X)` throws a `void-function nil` error if called on an X whose function definition isn't loaded (yet), but has been advised. This breaks ivy completion until it is restarted.

This PR does two things:

1. Address this error (possibly same issue as #50):

   ```
   Error in post-command-hook (ivy--queue-exhibit): (void-function nil)

   Debugger entered--Lisp error: (void-function nil)
      documentation(nil t)
      advice--make-docstring(some-function)
      documentation(some-function)
      eval((documentation 'some-function) t)
   ```

2. Stop ivy-rich-counsel-*-docstring functions from unnecessarily interning symbols.

**Steps to reproduce**

```elisp
;; 1. Advise a function that isn't defined, e.g.
(advice-add #'some-function :around #'adviser)
;; 2. then have ivy-rich try to display it
(ivy-rich-counsel-function-docstring "some-function")
```

