### PR TITLE
Improve buffer listing performance with projectile

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -199,7 +199,7 @@ using …."
 
 ;; Supports for `ivy-switch-buffer' ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defcustom ivy-rich-path-style
-  'relative
+  'abbrev
   "File path style.
 
 When set to 'full or 'absolute, absolute path will be used.

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -93,7 +93,6 @@ to hold the project name."
       (ivy-rich-switch-buffer-size (:width 7))
       (ivy-rich-switch-buffer-indicators (:width 4 :face error :align right))
       (ivy-rich-switch-buffer-major-mode (:width 12 :face warning))
-      (ivy-rich-switch-buffer-project (:width 15 :face success))
       (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
      :predicate
      (lambda (cand) (get-buffer cand)))

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -334,6 +334,43 @@ or /a/…/f.el."
 (defun ivy-rich-switch-buffer-project (candidate)
   (or (ivy-rich-switch-buffer-in-project-p candidate) ""))
 
+(defun ivy-rich--switch-buffer-filename (candidate)
+  (let* ((buffer (get-buffer candidate)))
+    (cl-destructuring-bind
+        (filename mode)
+        (ivy-rich--local-values buffer '(buffer-file-name major-mode))
+      (when (and filename
+                 (if (file-remote-p filename) ivy-rich-parse-remote-buffer t)
+                 (not (eq mode 'dired-mode)))
+        ;; when projectile is not available, we check for project mode and use
+        ;; it to disable file-truename (for some reason)
+        (when (not (and (not (bound-and-true-p projectile-mode))
+                        (require 'project nil t)))
+          (setq filename
+                (or (ivy-rich--local-values buffer 'buffer-file-truename)
+                    (file-truename filename))))
+        (expand-file-name filename)))))
+
+(defun ivy-rich--switch-buffer-root (candidate)
+  (let* ((buffer (get-buffer candidate)))
+    (cl-destructuring-bind
+        (directory mode)
+        (ivy-rich--local-values buffer '(default-directory major-mode))
+      (when (and directory
+                 (not (eq mode 'dired-mode))
+                 (ivy-rich-switch-buffer-in-project-p candidate))
+        ;; Find the project root directory or `default-directory'
+        (setq directory
+              (cond ((bound-and-true-p projectile-mode)
+                     (or (ivy-rich--local-values buffer
+                                                 'projectile-project-root)
+                         (with-current-buffer buffer
+                           (projectile-project-root))))
+                    ((require 'project nil t)
+                     (with-current-buffer buffer
+                       (car (project-roots (project-current)))))))
+        (expand-file-name directory)))))
+
 (defun ivy-rich--switch-buffer-root-and-filename (candidate)
   (let* ((buffer (get-buffer candidate))
          (truenamep t))
@@ -361,30 +398,39 @@ or /a/…/f.el."
         (cons (expand-file-name directory)
               (expand-file-name filename))))))
 
+(defun ivy-rich--switch-buffer-file-name-or-root (candidate)
+  (or (ivy-rich--switch-buffer-filename candidate)
+      (ivy-rich--switch-buffer-root candidate)))
+
 (defun ivy-rich-switch-buffer-path (candidate)
-  (if-let ((result (ivy-rich--switch-buffer-root-and-filename candidate)))
-      (cl-destructuring-bind (root . filename) result
-        (cond
-         ;; Case: absolute
-         ((or (memq ivy-rich-path-style '(full absolute))
-              (and (null ivy-rich-parse-remote-file-path)
-                   (or (file-remote-p root))))
-          (or filename root))
-         ;; Case: abbreviate
-         ((memq ivy-rich-path-style '(abbreviate abbrev))
-          (abbreviate-file-name (or filename root)))
-         ;; Case: relative
-         ((or (eq ivy-rich-path-style 'relative)
-              t)            ; make 'relative default
-          (if (and filename root)
-              (let ((relative-path (string-remove-prefix root filename)))
-                (if (string= relative-path candidate)
-                    (file-name-as-directory
-                     (file-name-nondirectory
-                      (directory-file-name (file-name-directory filename))))
-                  relative-path))
-            ""))))
-    ""))
+  (cond
+   ;; Case: abbreviate
+   ((memq ivy-rich-path-style '(abbreviate abbrev))
+    (if-let ((path (ivy-rich--switch-buffer-file-name-or-root candidate)))
+        (abbreviate-file-name path)))
+   ;; Case: absolute
+   ((memq ivy-rich-path-style '(full absolute))
+    (ivy-rich--switch-buffer-file-name-or-root candidate))
+   ;; Case: remote
+   (t
+    (if-let
+        ((result (ivy-rich--switch-buffer-root-and-filename candidate)))
+        (cl-destructuring-bind (root . filename) result
+          (cond
+           ((and (null ivy-rich-parse-remote-file-path)
+                 (file-remote-p root))
+            (or filename root))
+           ;; Case: relative
+           ((or (eq ivy-rich-path-style 'relative)
+                t)            ; make 'relative default
+            (if (and filename root)
+                (let ((relative-path (string-remove-prefix root filename)))
+                  (if (string= relative-path candidate)
+                      (file-name-as-directory
+                       (file-name-nondirectory
+                        (directory-file-name (file-name-directory filename))))
+                    relative-path))
+              ""))))))))
 
 ;; Supports for `counsel-M-x', `counsel-describe-function', `counsel-describe-variable'
 (defun ivy-rich-counsel-function-docstring (candidate)


### PR DESCRIPTION
The code that gets the buffer path referred to projectile far too eagerly. Only
when the file path of the buffer wasn't known it was necessary to get the
projectile root.

This commit makes use of the above to fetch the buffer path and the project root
in separate functions. This is slower in somse cases where both values are
required, but is much faster in the majority of cases.

The old code path for whenever ivy-rich-path-style isn't one of full, abbrev is
retained as it's more difficult to implement the optimization correctly in those
clauses.

The last 2 commits change the defaults so that users always get a responsive user experience out of the box:
* Remove the project name from the default list of columns
* Change the style to `'abbrev` as it doesn't require the project root in most cases.

This commit fixes all the performance problems of #56 for me.