### PR TITLE
Fix ivy-rich-file-last-modified-time

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -411,9 +411,10 @@ or /a/…/f.el."
 
 ;; Supports for `counsel-recentf'
 (defun ivy-rich-file-last-modified-time (candidate)
-  (if (file-remote-p candidate)
-      "?"
-    (format-time-string "%Y-%m-%d %H:%M:%S" (nth 5 (file-attributes candidate)))))
+  (let ((candidate (expand-file-name candidate ivy--directory)))
+    (if (file-remote-p candidate)
+        "?"
+      (format-time-string "%Y-%m-%d %H:%M:%S" (nth 5 (file-attributes candidate))))))
 
 ;; Supports for `counsel-bookmark'
 (defun ivy-rich-bookmark-value (candidate key)


### PR DESCRIPTION
file-remote-p works only if the candidate is expanded.