### PR TITLE
Add "ext:" to declare-function invocations

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -35,9 +35,9 @@
 (require 'ivy)
 (require 'subr-x)
 
-(declare-function projectile-project-name "projectile")
-(declare-function projectile-project-p "projectile")
-(declare-function projectile-project-root "projectile")
+(declare-function projectile-project-name "ext:projectile")
+(declare-function projectile-project-p "ext:projectile")
+(declare-function projectile-project-root "ext:projectile")
 
 (defgroup ivy-rich nil
   "More friendly interface (display transformer) for ivy."


### PR DESCRIPTION
Per the docstring for declare-function, add "ext:" to packages not in
core Emacs.


----

#