### PR TITLE
Use alist functions on `ivy--display-transformers-alist`.

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -485,13 +485,13 @@ or /a/…/f.el."
   (setq ivy-rich--original-display-transformers-list
         (plist-put ivy-rich--original-display-transformers-list
                    cmd
-                   (plist-get ivy--display-transformers-alist cmd))))
+                   (alist-get cmd ivy--display-transformers-alist))))
 
 (defun ivy-rich-restore-transformer (cmd)
   (setq ivy--display-transformers-alist
-        (plist-put ivy--display-transformers-alist
-                   cmd
-                   (plist-get ivy-rich--original-display-transformers-list cmd))))
+        (ivy--alist-set 'ivy--display-transformers-alist
+                        cmd
+                        (plist-get ivy-rich--original-display-transformers-list cmd))))
 
 (defun ivy-rich-build-transformer (cmd transformer-props)
   (if (functionp transformer-props)


### PR DESCRIPTION
Fixes #83.