### PR TITLE
Make buffer directory only show where relevant

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -311,9 +311,9 @@ or /a/…/f.el."
         (if fn
             ;; return containing directory
             (directory-file-name fn)
-          ;; else if mode explicitly offering list-buffers-directory, return that; else nil
-          ;; (buffers that don't explicitly visit files, but would like to show something,
-          ;;  e.g. magit or dired, use this)
+          ;; else if mode explicitly offering list-buffers-directory, return that; else nil.
+          ;; buffers that don't explicitly visit files, but would like to show a filename,
+          ;; e.g. magit or dired, set the list-buffers-directory variable
           (buffer-local-value 'list-buffers-directory buffer))))
 
 (defun ivy-rich-switch-buffer-root (candidate)

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -304,11 +304,20 @@ or /a/…/f.el."
      (symbol-name (ivy-rich--local-values candidate 'major-mode))))))
 
 (defun ivy-rich--switch-buffer-directory (candidate)
-  (or (ivy-rich--local-values candidate 'default-directory)
-      (ivy-rich--local-values candidate 'list-buffers-directory)))
+      "Return directory of file visited by buffer named CANDIDATE, or nil if no file."
+      (let* ((buffer (get-buffer candidate))
+             (fn (buffer-file-name buffer)))
+        ;; if valid filename, i.e. buffer visiting file:
+        (if fn
+            ;; return containing directory
+            (directory-file-name fn)
+          ;; else if mode explicitly offering list-buffers-directory, return that; else nil
+          ;; (buffers that don't explicitly visit files, but would like to show something,
+          ;;  e.g. magit or dired, use this)
+          (buffer-local-value 'list-buffers-directory buffer))))
 
 (defun ivy-rich-switch-buffer-root (candidate)
-  (let* ((dir (ivy-rich--switch-buffer-directory candidate)))
+  (when-let* ((dir (ivy-rich--switch-buffer-directory candidate)))
     (unless (or (and (file-remote-p dir)
                      (not ivy-rich-parse-remote-buffer))
                 ;; Workaround for `browse-url-emacs' buffers , it changes


### PR DESCRIPTION
Previously, directories would be shown for file-less buffers like `*scratch*`
or `*Messages*`. This change makes sure that directories are only shown for
buffers that actually have one, for example dired and magit, and buffers visiting
real files.

P.S. I saw that you added ffip support in https://github.com/Yevgnen/ivy-rich/commit/dbc41416c400f766a228448a77bbf64c0e108be6 shortly after my blog post appeared https://www.reddit.com/r/emacs/comments/jv2ms7/fix_nondisplay_of_ivyrich_switch_buffer/

Thanks!

This small PR is an improved version of the second part of that blog, and ensures that buffers like `*scratch*` and `*Messages*` don't show directories, and that the directory extraction for other buffers is more exact. See before and after screenshots below.

## Before

![image](https://user-images.githubusercontent.com/937871/99373254-dc084880-28c9-11eb-84ed-a99edaca25ae.png)

## After

![image](https://user-images.githubusercontent.com/937871/99373295-e6c2dd80-28c9-11eb-990c-2a15c8500647.png)
