### PR TITLE
Add convenience functions for customizing transformer columns

### DIFF
--- a/README.org
+++ b/README.org
@@ -119,6 +119,36 @@ properties.* Each plist key is a ~ivy~ command and plist value is its
 transformer format definitions or a pre-defined transformer. Refer to
 the documentation of ~ivy-rich-display-transformers-list~ for details.
 
+Convenience functions exist for customizing column properties without
+rewriting the entire transformer definition. Below are two examples with
+`use-package` that use the default transformers, but with user-defined
+customizations.
+
+This example customizes the `:width` and `:face` properties of the major
+mode column in the `ivy-switch-buffer` transformer:
+
+#+begin_src elisp
+(use-package ivy-rich
+  :config
+  (ivy-rich-modify-column 'ivy-switch-buffer
+                          'ivy-rich-switch-buffer-major-mode
+                          '(:width 20 :face error)))
+#+end_src
+
+This example customizes properties of two columns of the `ivy-switch-buffer`
+transformer and shows some other configuration options via `use-package`:
+
+#+begin_src elisp
+(use-package ivy-rich
+  :hook (ivy-mode . ivy-rich-mode)
+  :custom (ivy-rich-path-style 'abbrev)
+  :config
+  (ivy-rich-modify-columns
+   'ivy-switch-buffer
+   '((ivy-rich-switch-buffer-size (:align right))
+     (ivy-rich-switch-buffer-major-mode (:width 20 :face error)))))
+#+end_src
+
 *** Example
 
 **** ~counsel-M-x~

--- a/README.org
+++ b/README.org
@@ -121,11 +121,11 @@ the documentation of ~ivy-rich-display-transformers-list~ for details.
 
 Convenience functions exist for customizing column properties without
 rewriting the entire transformer definition. Below are two examples with
-`use-package` that use the default transformers, but with user-defined
+~use-package~ that use the default transformers, but with user-defined
 customizations.
 
-This example customizes the `:width` and `:face` properties of the major
-mode column in the `ivy-switch-buffer` transformer:
+This example customizes the ~:width~ and ~:face~ properties of the major
+mode column in the ~ivy-switch-buffer~ transformer:
 
 #+begin_src elisp
 (use-package ivy-rich
@@ -135,8 +135,8 @@ mode column in the `ivy-switch-buffer` transformer:
                           '(:width 20 :face error)))
 #+end_src
 
-This example customizes properties of two columns of the `ivy-switch-buffer`
-transformer and shows some other configuration options via `use-package`:
+This example customizes properties of two columns of the ~ivy-switch-buffer~
+transformer and shows some other configuration options via ~use-package~:
 
 #+begin_src elisp
 (use-package ivy-rich

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -156,6 +156,47 @@ without duplicating definitions.
 Note that you may need to disable and enable the `ivy-rich-mode'
 again to make this variable take effect.")
 
+;;; User convenience functions
+;; Helper functions for user profile configuration
+
+(defun ivy-rich-modify-column (cmd column attrs)
+  "Customize the CMD transformer's properties for a specific COLUMN.
+Each key-value pair in ATTRS is put into the property list for the column.
+Existing properties for the column are left unchanged.
+
+Usage:
+
+(ivy-rich-modify-column 'ivy-switch-buffer
+                        'ivy-rich-switch-buffer-major-mode
+                        '(:width 20 :face error))"
+  (if (evenp (length attrs))
+      (let* ((trans (plist-get ivy-rich-display-transformers-list cmd))
+             (props (cadr (assoc column (plist-get trans :columns)))))
+        (while attrs
+          (plist-put props (pop attrs) (pop attrs))))
+    (error "Column key-value attributes must be in pairs")))
+
+(defun ivy-rich-modify-columns (cmd column-list)
+  "Customize the CMD transformer's properties for a COLUMN-LIST.
+This is a convenience function that calls `ivy-rich-modify-column' for each item
+in COLUMN-LIST, allowing multiple columns to be modified for a transformer.
+Each item in COLUMN-LIST is a two-item list comprised of a column and list
+of attribute key-value pairs.
+
+Usage:
+
+(ivy-rich-modify-columns
+ 'ivy-switch-buffer
+ '((ivy-rich-switch-buffer-size (:align right))
+   (ivy-rich-switch-buffer-major-mode (:width 20 :face error))))"
+  (while column-list
+    (if-let ((column (caar column-list))
+             (attrs (cadar column-list)))
+        (prog1
+            (ivy-rich-modify-column cmd column attrs)
+          (setq column-list (cdr column-list)))
+      (error "Column/attributes are incorrectly specified"))))
+
 ;; Common Functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defalias 'ivy-rich-candidate 'identity)
 


### PR DESCRIPTION
This enables customization of a column properties without rewriting the entire transformer definition. Two functions are defined; the latter is a wrapper around the former:

- ivy-rich-modify-column
- ivy-rich-modify-columns

Closes Yevgnen/ivy-rich#95