### PR TITLE
Introduce ivy-rich-project-root-cache-mode (#93)

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,6 +31,7 @@
   - [[#basic-usages][Basic Usages]]
   - [[#customization][Customization]]
   - [[#notes][Notes]]
+  - [[#ivy-switch-buffer-project-performance][~ivy-switch-buffer~ Project Performance]]
 - [[#screenshots-and-details][Screenshots and details]]
   - [[#ivy-switch-buffer][~ivy-switch-buffer~]]
   - [[#counsel-m-x][~counsel-M-x~]]
@@ -222,6 +223,16 @@ You will get
    package. But if you set the transformer to ~some-function~ before
    enabling ~ivy-rich-mode~, disabling the minor mode will restore it to
    ~some-function~ other than ~ivy-switch-buffer-transformer~.
+
+** ~ivy-switch-buffer~ Project Performance
+
+When having many open buffers, calling and navigating ~ivy-switch-buffers~
+might become slow when you have project-related columns. If that's the
+case, you can enable ~ivy-rich-project-root-cache-mode~, to cache each
+buffers project. The project for a buffer is cached until the buffer is
+killed, ~ivy-rich-project-root-cache-mode~ is disabled or
+~ivy-rich-clear-project-root-cache~ is called.
+
 
 * Screenshots and details
 :PROPERTIES:

--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -360,7 +360,7 @@ or /a/…/f.el."
           ;; e.g. magit or dired, set the list-buffers-directory variable
           (buffer-local-value 'list-buffers-directory buffer))))
 
-(defvar ivy-rich-project-root-cache
+(defvar ivy-rich--project-root-cache
   (make-hash-table :test 'equal)
   "Hash-table caching each file's project for
 `ivy-rich-switch-buffer-root'.
@@ -373,9 +373,9 @@ The cache can be cleared manually by calling
 `ivy-rich-clear-project-root-cache'.")
 
 (defun ivy-rich-clear-project-root-cache ()
-  "Resets `ivy-rich-project-root-cache'."
+  "Resets `ivy-rich--project-root-cache'."
   (interactive)
-  (clrhash ivy-rich-project-root-cache))
+  (clrhash ivy-rich--project-root-cache))
 
 (defun ivy-rich-switch-buffer-root-lookup (candidate dir)
   (unless (or (and (file-remote-p dir)
@@ -399,20 +399,21 @@ The cache can be cleared manually by calling
 (defun ivy-rich-switch-buffer-root (candidate)
   (when-let* ((dir (ivy-rich--switch-buffer-directory candidate)))
     (let ((cached-value (if ivy-rich-project-root-cache-mode
-                            (gethash dir ivy-rich-project-root-cache 'not-found)
+                            (gethash dir ivy-rich--project-root-cache 'not-found)
                           'not-found)))
-      (if (not (eq cached-value 'not-found)) cached-value
+      (if (not (eq cached-value 'not-found))
+          cached-value
         (let ((value (ivy-rich-switch-buffer-root-lookup candidate dir)))
           (when ivy-rich-project-root-cache-mode
-            (puthash dir value ivy-rich-project-root-cache))
+            (puthash dir value ivy-rich--project-root-cache))
           value)))))
 
 (defun ivy-rich-project-root-cache-kill-buffer-hook ()
   "This hook is used to remove buffer from
-`ivy-rich-project-root-cache' when they are killed."
+`ivy-rich--project-root-cache' when they are killed."
   (remhash (ivy-rich--switch-buffer-directory
             (buffer-name (current-buffer)))
-           ivy-rich-project-root-cache))
+           ivy-rich--project-root-cache))
 
 (defun ivy-rich-switch-buffer-project (candidate)
   (file-name-nondirectory


### PR DESCRIPTION
While the global ivy-rich-project-root-cache-mode minor mode is enabled, the results of ivy-rich-switch-buffer-root are cached in a hash-table and evicted once the buffer is killed or the minor mode is disabled again.

I decided to use a minor mode, not a config option as suggested in my comment, because that felt more fitting here, as we register a kill-buffer-hook.

This should fix #93.