### PR TITLE
* ivy-rich.el: fix Error in post-command-hook (use another function to get directory)

### DIFF
--- a/ivy-rich.el
+++ b/ivy-rich.el
@@ -390,7 +390,7 @@ or /a/…/f.el."
         ;; if valid filename, i.e. buffer visiting file:
         (if fn
             ;; return containing directory
-            (directory-file-name fn)
+            (file-name-directory fn)
           ;; else if mode explicitly offering list-buffers-directory, return that; else nil.
           ;; buffers that don't explicitly visit files, but would like to show a filename,
           ;; e.g. magit or dired, set the list-buffers-directory variable


### PR DESCRIPTION
There's an issue (https://github.com/Yevgnen/ivy-rich/issues/115) where we have an "Error in post-command-hook" every time when trying to switch buffers. This fixes it.